### PR TITLE
Feature/development run all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 package-lock.json
 dist
+src/*.js
+src/*.js.map

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,10 @@ The Now 2.0 platform handles [routing](https://github.com/styfle/og-image/blob/m
 
 However, local development requires a few steps.
 
-1. Run `npm run watch` to get TS to JS compilation file watch running (compiles on save)
-2. Run the backend with `npm start` (you can try it by visiting http://localhost:13463/Nice.png)
-3. Run the frontend with `npx http-server .` and visit http://localhost:8080/public/index.html
-4. If necessary, edit the `exePath` in [options.ts](https://github.com/styfle/og-image/blob/master/src/options.ts) to point to your local Chrome executable
+1. Run `npm run develop` to get 
+   1. TS to JS compilation file watch running (compiles on save)
+   2. Run the backend (you can try it by visiting http://localhost:13463/Nice.png)
+   3. Run the frontend and visit http://localhost:8080/public/index.html
+2. If necessary, edit the `exePath` in [options.ts](https://github.com/styfle/og-image/blob/master/src/options.ts) to point to your local Chrome executable
 
 Now you're ready to start local development!

--- a/now.json
+++ b/now.json
@@ -13,7 +13,7 @@
         { "src": "/", "dest": "/public/index.html" },
         { "src": "/favicon.ico", "dest": "/public/favicon.ico" },
         { "src": "/style.css", "dest": "/public/style.css" },
-        { "src": "/public/dist/browser.js", "dest": "/browser.js" },
+        { "src": "/public/dist/browser.js", "dest": "/public/browser.js" },
         { "src": "/(.+)", "dest": "/src/card.ts" }
     ]
 }

--- a/now.json
+++ b/now.json
@@ -13,7 +13,6 @@
         { "src": "/", "dest": "/public/index.html" },
         { "src": "/favicon.ico", "dest": "/public/favicon.ico" },
         { "src": "/style.css", "dest": "/public/style.css" },
-        { "src": "/public/dist/browser.js", "dest": "/public/browser.js" },
         { "src": "/(.+)", "dest": "/src/card.ts" }
     ]
 }

--- a/now.json
+++ b/now.json
@@ -6,7 +6,7 @@
     "public": true,
     "builds": [
         { "src": "public/*", "use": "@now/static" },
-        { "src": "package.json", "use": "@now/static-build" },
+        { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "public/dist" } },
         { "src": "src/card.ts", "use": "@now/node@canary", "config": { "maxLambdaSize": "40mb" } }
     ],
     "routes": [

--- a/now.json
+++ b/now.json
@@ -13,7 +13,7 @@
         { "src": "/", "dest": "/public/index.html" },
         { "src": "/favicon.ico", "dest": "/public/favicon.ico" },
         { "src": "/style.css", "dest": "/public/style.css" },
-        { "src": "/dist/browser.js", "dest": "/browser.js" },
+        { "src": "/public/dist/browser.js", "dest": "/browser.js" },
         { "src": "/(.+)", "dest": "/src/card.ts" }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "og-image",
   "version": "1.0.1",
   "description": "Generate an open graph image for twitter/facebook/etc",
-  "main": "dist/card.js",
+  "main": "public/dist/card.js",
   "scripts": {
-    "start": "node dist/card.js",
+    "start": "node public/dist/card.js",
     "build": "tsc",
     "now-build": "tsc",
     "watch": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "og-image",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate an open graph image for twitter/facebook/etc",
   "main": "dist/card.js",
   "scripts": {
     "start": "node dist/card.js",
     "build": "tsc",
     "now-build": "tsc",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "http-server": "http-server -p 8080 -a localhost -o",
+    "develop": "run-p watch start http-server"
   },
   "author": "styfle",
   "repository": "github:styfle/og-image",
@@ -20,6 +22,8 @@
   "devDependencies": {
     "@types/marked": "^0.6.0",
     "@types/puppeteer-core": "^1.9.0",
+    "http-server": "^0.11.1",
+    "npm-run-all": "^4.1.5",
     "typescript": "^3.2.4"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
     </div>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/dot-dom@0.3.0/dotdom.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/copee@1.0.6/dist/copee.umd.js"></script>
-    <script type="text/javascript" src="../dist/browser.js"></script>
+    <script type="text/javascript" src="dist/browser.js"></script>
 </body>
 
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "outDir": "dist",
+        "outDir": "public/dist",
         "module": "commonjs",
         "target": "esnext",
         "moduleResolution": "node",


### PR DESCRIPTION
Several changes in this PR, but it's all an effort to make it easier to contribute to the project.

1. Combine the 3 commands into the CONTRIBUTING.md into one (npm watch, start, and npx http-server). 
  1.  Removes dependency of npx
2. Adds http-server and npm-run-all to devDependencies
3. Compile TS files to public (move "dist" to "public/dist") to make http-server work without npx.